### PR TITLE
Adds english version

### DIFF
--- a/EN.md
+++ b/EN.md
@@ -125,7 +125,7 @@ The following strategies can be used to authenticate API users:
 * JSON Web Tokens (a bit more complex)
 
 **Authorization** - granting a particular user the rights for performing specific actions. 
-For instance: a user who has been banned by admin cannot post comments (even though they have been successfully authenticated). 
+For instance: a user who was banned by admin cannot post comments (even though they have been successfully authenticated). 
 
 Some examples of libraries:
 - [Pundit for Ruby](https://github.com/varvet/pundit)
@@ -152,51 +152,52 @@ Goal: split the responsibilities between components. MVC is a type of architectu
 * Builds an API response based on data passed to it
 
 # 📐✏️👷‍♀️Architecture, Design Patterns, Refactoring, etc
-После того как MVC стал открытой книгой стоит углубиться и изучить:
-- подходы к построению архитектуры приложения
-- принципы которые помогают писать код устойчивый к изменениям.
+After grasping the concept of MVC, try developing a deeper understanding and study:
+- different app architecture approaches
+- patterns that can make your code future-proof
 
-Бесплатные ресурсы, которые рекомендую для старта:
+A few courses that I recommend:
 - [Categorized overview of programming principles & design patterns](https://github.com/webpro/programming-principles)
 - [Refactoring Patterns and Design Patters Reference](https://refactoring.guru)
 - [Summary of "Clean code" by Robert C. Martin](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
 - [Summary of "Clean Architecture" by Robert C. Martin](https://gist.github.com/ygrenzinger/14812a56b9221c9feca0b3621518635b)
 
 # 🔒CRUD: Validations
-Перед тем как сохранять данные в БД обязательно:
-- отвалидируйте данные на тип (там где ожидается строка пришла строка, где int там int итп)
-- и соответствие тела запроса API (если пользователь отправил поля которые не имеет права отпралять в БД мы должны их игнорировать)
+Before persisting data in the database, one should:
+- validate the the types (e.g. rows that expect string data types receive string data etc.)
+- ensure API request body consitency (if a request contains fields that do not have matching columns in the databsae, these fields should be ignored)
 # CRUD: Database
-* Используйте ORM (или что-то подобное), если в задании не указано что нужно писать чистый SQL.
-  * Проще для старта
-  * Безопасно (Большинство ORM предоставлют защиту от SQL injections из коробки)
-* Используйте механизм миграций чтобы создавать таблицы и другие сущности в вашей БД (Rails Migrations, Flask-Migrate, etc)
-* При описании таблиц важно сразу указать всем столбцам необходимые constraints (NULLABLE, DEFAULT VALUE, UNIQUE, PRIMARY KEY)
-* При описании таблиц важно сразу указать индексы для столбцов по которым ожидается поиск.
-* Для защиты API от перебора можно использовать как PRIMARY KEY `uuid` вместо `serial`
+* Use and ORM (or a similar tool), unless your requirements specify using pure SQL.
+  * Easier to operate
+  * Safe, because most ORMs offer protection against common SQL vulnurabilities out of the box. 
+* Use migrations to create tables and other entities in your DB (Rails Migrations, Flask-Migrate, etc)
+* When describing tables, it is important to specify required constraints (NULLABLE, DEFAULT VALUE, UNIQUE, PRIMARY KEY)
+* When describing tables, it is important to specify indicies for columns that are expected to be indexed.
+* To protect an API from sequencing attacks, you can try using a `uuid` instead of a `serial`
 
 
-P.S. При описании миграций полезно подсматривать [сюда](https://github.com/ankane/strong_migrations), чтобы не написать миграцию которая может заблокировать БД.
+P.S. Try following the principle of [strong migrations](https://github.com/ankane/strong_migrations) to avoid blocking the DB. 
 # CRUD: Operations
 ## LIST (HTTP GET)
-* Для каждого ресурса в ответе должно присутствовать ID.
-* Ресурсы должны быть отсортированными по какому либо признаку, например по времени создания.
-* API должен поддерживать пагинацию (чтобы не возвращать все сущности из БД за раз) [Разбор вариантов пагинации](https://dev.to/appwrite/this-is-why-you-should-use-cursor-pagination-4nh5)
-* Количество запросов к БД в рамках запроса должно быть фиксированным (Отсутствует [N+1 проблема](https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem-in-orm-object-relational-mapping))
+* A response should include ID(s) for every resource.
+* Resources should be sorted by some type of attribute such as date of creation.
+* An API should support pagination to avoid returning all resources at one. [Database pagination techniques](https://dev.to/appwrite/this-is-why-you-should-use-cursor-pagination-4nh5)
+* The number of requests to the database within a single API request must be limited avoiding [the N+1 queries problem](https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem-in-orm-object-relational-mapping)
 
-API не должно возвращать все поля модели.
-Пример: если наше API возвращает список постов то оно должно возвращать:
+An API should not return all the fields for a model.
+Example of a response for a list of articles: 
   * ID
-  * Название поста
-  * Имя автора
-  * Первые несколько предложений статьи (превью)
+  * Title
+  * Author name
+  * First few sentences of the body
 
-Полный текст поста для этого эндпоинта не нужен.
+Sending full text body is really unncessary.  
 
 ## READ (HTTP GET)
-* Возвращаем полностью ресурс со всеми полями, ничего особенного
+* Returning a resources with all of its fields. Nothing special here.
 ## CREATE (HTTP POST)
 * Валидируем данные на предмет полей которые пользователь не имеет права изменять в БД а следовательно передавать.
+* We validate 
 * Делаем в БД INSERT
 * Возвращаем в ответ ID и содержимое.
 

--- a/EN.md
+++ b/EN.md
@@ -94,61 +94,62 @@ Try to adhere to the [testing pyramid] (https://martinfowler.com/articles/practi
   * [Best practices when writing a Dockerfile for a Ruby application](https://lipanski.com/posts/dockerfile-ruby-best-practices) (although, these tips can be useful for other languages)
   * [Google Cloud: Best practices for building containers](https://cloud.google.com/architecture/best-practices-for-building-containers)
 * All app dependencies are listed in a `docker-compose.yml` file
-* Set up and launch ofr your application should be as easy nad straightforward. It is possible that you may need to write some additional `base/zsh/powershell` scripts
+* Setting up and launching your application should be as easy and straightforward. It is possible that you may need to write some additional `base/zsh/powershell` scripts
 * [Your application should have multiple environments (development, prod, test)](https://12factor.net/dev-prod-parity)
-* Для `production` сборки приложения используется рекомендуемый application сервер, например:
+* Use a suitable application server for your `production` environment. For example: 
    * Puma for Ruby
    * Gunicorn3 for Python
    * Undertow for Java
 
-При описании конфигурации приложения используйте принципы 12factor. Изображение взято из статьи: [12 Factor App Revisited](https://architecturenotes.co/12-factor-app-revisited/)
+When writing the configuration for your application, use the 12factor principles. The diagram below is copied from the [12 Factor App Revisited](https://architecturenotes.co/12-factor-app-revisited/) article
 <img src="https://raw.githubusercontent.com/abstractart/how-to-develop-perfect-crud/main/12-Factor-app-revised.jpg">
 
-
 # API Design
-* Используй конвенции [REST](https://www.freecodecamp.org/news/rest-api-best-practices-rest-endpoint-design-examples/) как фундамент при именовании путей, типов операций и выборе статусов ответов API  
-* Формат данных: JSON (если не требуется другого)
-* В репозитории есть возможность открыть [Swagger](https://swagger.io/) спецификацию для знакомства с API
-  * Её можно написать самостоятельно
-  * А можно генерировать c помощью утилит: [rswag (Rails)](https://github.com/rswag/rswag), [safrs (Flask)](https://github.com/thomaxxl/safrs), [echo-swagger (Echo/Golang)](https://github.com/swaggo/echo-swagger)
-
+* Use the REST](https://www.freecodecamp.org/news/rest-api-best-practices-rest-endpoint-design-examples/) architecture conventions as your guiding principle for naming paths, types of operations and API response statuses.
+* Response type: JSON (unless otherwise specified)
+* There is an option to open Swagger in your repository to familiarize the next developer with your API design
+  * It can be written by hand
+  * Or you can use a codegen: [rswag (Rails)](https://github.com/rswag/rswag), [safrs (Flask)](https://github.com/thomaxxl/safrs), [echo-swagger (Echo/Golang)](https://github.com/swaggo/echo-swagger)
+  
 Если считаешь что связка REST+JSON не подходит под задачу, или по заданию требуется другой формат, то стоит изучить альтернативы:
+If you think that REST+JSON option is not a great fit for your application design, or your task requires using a different format, it could be beneficial to familiarize yourself with some alternatives:
 - [SOAP](https://www.w3.org/TR/soap12-part1/)
 - [gRPC](https://grpc.io/)
 - [GraphQL](https://graphql.org/)
 
-# Authorization & Authentification
-**Аутентификация** – процедура проверки подлинности, например, проверка подлинности пользователя путем сравнения введенного им пароля с паролем, сохраненным в базе данных.
+# Authorization & Authentication
+**Authentication** - is a process of verifying a user identity. The most common way to authenticate a user is to compare the password they entered with the password saved in the database.
 
-В качестве аутентификации по API можно использовать:
-* HTTP Basic Auth (простой путь)
-* JSON Web Tokens (посложнее)
+The following strategies can be used to authenticate API users: 
+* HTTP Basic Auth (easy)
+* JSON Web Tokens (a bit more complex)
 
-**Авторизация** – предоставление определенному лицу прав на выполнение определенных действий.
-Например: пользователь которого забанил администратор не может публиковать комментарии к постам (хотя он прошел аутентификацию на сайте).
+**Authorization** - granting a particular user the rights for performing specific actions. 
+For instance: a user who has been banned by admin cannot post comments (even though they have been successfully authenticated). 
 
-Примеры библиотек:
+Some examples of libraries:
 - [Pundit for Ruby](https://github.com/varvet/pundit)
 - [Casbin (Many languages supported)](https://github.com/casbin/casbin)
 
 # MVC Explanation
-Цель: разделить обязанности в коде между компонентами. MVC это один из вариантов достижения цели и не требует от разработчика сильной когнитивной нагрузки (по сравнению с другими подходами)
+Goal: split the responsibilities between components. MVC is a type of architecture that allows a developer to build applications without excessive cognitive load (compared to other web architecture types) 
+
 <img src="https://github.com/abstractart/how-to-develop-perfect-crud/blob/main/mvc-with-service.png?raw=true">
 ## Controller
-- Принимает тело запроса, валидирует его на соответствие API
-- Проверяет authorization + authentification 
-- Вызывает Service, передает ему данные
-- На основе возвращаемого значения от Service вызывает код формирующий нужный ответ API (через View)
+- Accepts the request and validates request body based on rules set within your API
+- Checks authorization + authentication
+- Calls a Service and injects data into it 
+- Based on Service return, a controller formats a response and passes it into a View
 ## Model
-* Хранит только описание схемы данных и связи с другими моделями
-* Бизнес логики хранит по минимуму а лучше не хранит вообще
-* Используется для того чтобы делать запросы к БД на чтение и запись
+* Reflects basic description of schema and relations with other models
+* Contains minimum business logic, or ideally none at all
+* Is used to make requests to the DB for reads and writes
 ## Service
-* Принимает данные от контроллера, валидирует тело
-* Использует Model для чтения или записи данных в БД.
-* Отвечает за бизнес-логику приложения
+* Accepts arguments from controllers and validates the request body
+* Uses a Model for reading and writing data to DB.
+* Is responsible for the business logic of your application
 ## View
-* Отвечает за то чтобы на основе данных сформировать API ответ.
+* Builds an API response based on data passed to it
 
 # 📐✏️👷‍♀️Architecture, Design Patterns, Refactoring, etc
 После того как MVC стал открытой книгой стоит углубиться и изучить:

--- a/EN.md
+++ b/EN.md
@@ -2,7 +2,7 @@
 [<img src="https://img.shields.io/badge/channel-telegram-blue">](https://t.me/careerunderhood) [<img src="https://img.shields.io/badge/message-telegram-blue">](https://t.me/ea_kozlov)
 
 # 🤔 What is this?
-This article is an attempt to combine best practices that are helpful to keep in mind when developing backend applications.
+This article is an attempt to combine good practices that are useful to keep in mind and apply when developing a backend application.
 
 It can be used as a checklist if:
 - You are starting a greenfield project and want to ensure that best practices are used right from the start.
@@ -27,7 +27,7 @@ If you have a proposal about covering a specific technology here, don't be shy:
 - [✔️Tests](#%EF%B8%8Ftests)
 - [⚙️Configuration & Infrastructure around Code](#%EF%B8%8Fconfiguration--infrastructure-around-code)
 - [API Design](#api-design)
-- [Authorization & Authentification](#authorization--authentification)
+- [Authorization & Authentication](#authorization--authentification)
 - [MVC Explanation](#mvc-explanation)
   - [Controller](#controller)
   - [Model](#model)
@@ -63,7 +63,7 @@ If you have a proposal about covering a specific technology here, don't be shy:
 * `feature/` and master branches should be set up with:
   * test runners and [coverage](https://www.guru99.com/test-coverage-in-software-testing.html) stats
   * linting  
-* Setting up Continuous Delivery - app delpoyment into differnet environmetns (e.g. test/staging/prod) would be a huge plus!
+* Setting up Continuous Delivery - app deployment into different environments (e.g. test/staging/prod) would be a huge plus!
 * Optional: Set up [dependabot](https://docs.github.com/ru/code-security/dependabot/working-with-dependabot)
 
 # Code Style
@@ -111,7 +111,6 @@ When writing the configuration for your application, use the 12factor principles
   * It can be written by hand
   * Or you can use a codegen: [rswag (Rails)](https://github.com/rswag/rswag), [safrs (Flask)](https://github.com/thomaxxl/safrs), [echo-swagger (Echo/Golang)](https://github.com/swaggo/echo-swagger)
   
-Если считаешь что связка REST+JSON не подходит под задачу, или по заданию требуется другой формат, то стоит изучить альтернативы:
 If you think that REST+JSON option is not a great fit for your application design, or your task requires using a different format, it could be beneficial to familiarize yourself with some alternatives:
 - [SOAP](https://www.w3.org/TR/soap12-part1/)
 - [gRPC](https://grpc.io/)
@@ -135,6 +134,7 @@ Some examples of libraries:
 Goal: split the responsibilities between components. MVC is a type of architecture that allows a developer to build applications without excessive cognitive load (compared to other web architecture types) 
 
 <img src="https://github.com/abstractart/how-to-develop-perfect-crud/blob/main/mvc-with-service.png?raw=true">
+
 ## Controller
 - Accepts the request and validates request body based on rules set within your API
 - Checks authorization + authentication
@@ -164,15 +164,15 @@ A few courses that I recommend:
 
 # 🔒CRUD: Validations
 Before persisting data in the database, one should:
-- validate the the types (e.g. rows that expect string data types receive string data etc.)
-- ensure API request body consitency (if a request contains fields that do not have matching columns in the databsae, these fields should be ignored)
+- validate the types (e.g. rows that expect string data types receive string data etc.)
+- ensure API request body consistency (if a request contains fields that do not have matching columns in the database, these fields should be ignored)
 # CRUD: Database
 * Use and ORM (or a similar tool), unless your requirements specify using pure SQL.
   * Easier to operate
-  * Safe, because most ORMs offer protection against common SQL vulnurabilities out of the box. 
+  * Safe, because most ORMs offer protection against common SQL vulnerabilities out of the box. 
 * Use migrations to create tables and other entities in your DB (Rails Migrations, Flask-Migrate, etc)
 * When describing tables, it is important to specify required constraints (NULLABLE, DEFAULT VALUE, UNIQUE, PRIMARY KEY)
-* When describing tables, it is important to specify indicies for columns that are expected to be indexed.
+* When describing tables, it is important to specify indices for columns that are expected to be indexed.
 * To protect an API from sequencing attacks, you can try using a `uuid` instead of a `serial`
 
 
@@ -191,72 +191,71 @@ Example of a response for a list of articles:
   * Author name
   * First few sentences of the body
 
-Sending full text body is really unncessary.  
+Sending a full text body is really unnecessary.
 
 ## READ (HTTP GET)
-* Returning a resources with all of its fields. Nothing special here.
+* Returning resources with all of their fields. Nothing special here.
 ## CREATE (HTTP POST)
-* Валидируем данные на предмет полей которые пользователь не имеет права изменять в БД а следовательно передавать.
-* We validate 
-* Делаем в БД INSERT
-* Возвращаем в ответ ID и содержимое.
+* Filter out fields that should not be accessed by users.
+* Commit the INSERT in our DB.
+* Send a response with our newly-created resource ID and content. 
 
-Задачи со звездочкой:
-- Убедиться что реализованное API идемпотентно: [Подробнее](https://habr.com/ru/company/yandex/blog/442762/)
-- Настроить Rate Limiter чтобы защитить БД от спама и мусора
+Bonus points:
+- Make sure that the API endpoint is [idempotent](https://restfulapi.net/idempotent-rest-apis/)
+- Set up a rate limiter to protect the database from spam
 ## UPDATE (HTTP PUT/PATCH)
-* Разобраться в чем отличие между PUT и PATCH в HTTP
-* Валидировать тело запроса на предмет полей которые пользователь не имеет права изменять в БД а следовательно передавать.
-* Проверка права на редактирование у пользователя
-  * Например API не должно позволять пользователю редактировать чужие комментарии :)
-* Реализовать обновление согласно выбранному методу
+* Know the difference between PUT and PATCH HTTP methods
+* Filter out fields that should not be accessed by users.
+* User authorization check
+  * Example: users should not be allowed to edit other users' comments.
+* Commit the update depending upon the selected HTTP method.
 
 ## DESTROY (HTTP DELETE)
-* Реализовать удаление предварительно проверив наличие сущности в БД и права на удаление у пользователя
+* Commit deletion after checking the existing of resource in the database and user authorization
 
-Дополнительно может быть полезно: реализовать soft удаление (скрываем от пользователя, оставляем в БД)
+Additionally, you might considering implementing "soft-deletion" (hide deleted resources from users, but keep them in the DB)
 # External API Calls, Long-running tasks (And why we need message queue)
-Если в рамках API требуется:
-- выполнять запросы к внешним системам
-- генерировать отчеты/выполнять долгие запросы к БД 
-то стоит подумать о том чтобы делать эти операции за пределами HTTP запроса. 
+If an API needs to:
+- send requests to third-party resources
+- generate reports or perform long requests to DB 
+then it might be a good idea to perform these operations outside of HTTP requests.
 
-Для этого может понадобиться очередь (Queue) в которую можно будет добавлять задачу (Task). 
+To do these operations, we will need a Queue, to which we'll add or remove Tasks.
 
-Примеры высокоуровневых библиотек которых решают задачу с постановкой, чтением и обработкой задач:
-* Celery for Python (Задачи хранятся в `Redis`)
-* Sidekiq for Ruby (Задачи хранятся в `Redis`)
+Examples of high-level libraries that solve the problem of scheduling, reading and processing tasks:
+* Celery for Python (tasks are stored in `Redis`)
+* Sidekiq for Ruby (tasks are stored in `Redis`)
 
-Стоит отметить, что `Redis` это не единственный вариант для хранения очереди + не для всех задач он подходит.
-Поэтому полезно изучить как минимум 2 более продвинутых варианта для хранения и обработки очередей: `RabbitMQ` и `Kafka`.
+It is important to note that Redis is not the only option and it might not be suitable for all types of applications. 
+Hence, it would be a good idea to learn at least two other advanced libraries for storing and processing queues - `RabbitMG` an d 'Kafka'
 
-Доп.ссылки:
-- [RabbitMQ и Apache Kafka: что выбрать](https://slurm.io/tpost/phdmogo9y1-rabbitmq-i-apache-kafka-chto-vibrat-i-mo)
-- [Latency, throughput, and availability: system design interview concepts](https://igotanoffer.com/blogs/tech/latency-throughput-availability-system-design-interview) - Подробнее о том, почему так важно чтобы HTTP запросы были быстрыми
+Additional links:
+- [Latency, throughput, and availability: system design interview concepts](https://igotanoffer.com/blogs/tech/latency-throughput-availability-system-design-interview) - A more detailed explanation of why fast processing HTTP requests is so important.
 
 # 📈Logs and Metrics
-- Настроить Prometheus метрики с информацией о состоянии HTTP API и райнтайме приложения. Рекомендуется использовать готовые пакеты, которые собирают метрики о работе приложения по методикам [RED (Rate Error Duration)](https://www.infoworld.com/article/3638693/the-red-method-a-new-strategy-for-monitoring-microservices.html) и [USE (Utilization Saturation Errors)](https://www.brendangregg.com/usemethod.html):
-  - [prometheus, promauto, promhttp для Go](https://prometheus.io/docs/guides/go-application/)
-  - [starlette-prometheus для Python](https://github.com/perdy/starlette-prometheus)
-- [Логи должны писаться только в stdout](https://12factor.net/logs)
-- [Логи должны иметь строгий формат, например это может быть JSON](https://coralogix.com/blog/json-logging-why-how-what-tips/)
+- et up Prometheus metrick with data about the state of HTTP API and application runtime. We recommend using settings that collect application performance metrics using RED (Rate Error Duration)](https://www.infoworld.com/article/3638693/the-red-method-a-new-strategy-for-monitoring-microservices.html) and [USE (Utilization Saturation Errors)](https://www.brendangregg.com/usemethod.html) methodologies:
+  - [prometheus, promauto, promhttp for Go](https://prometheus.io/docs/guides/go-application/)
+  - [starlette-prometheus for Python](https://github.com/perdy/starlette-prometheus)
+- [Logs should only be sent to stdout](https://12factor.net/logs)
+- [Logs should have a strict format like JSON](https://coralogix.com/blog/json-logging-why-how-what-tips/)
 
 
 # 🛡️Security
-- Убедись, что не используешь версии библиотек в которых есть уязвимости, проверять это можно автоматически с помощью утилит, например:
+- Check library versions you are using for known vulnerabilities. Some utilities that can audit your libraries are:
   - [bundler-audit for Ruby](https://github.com/rubysec/bundler-audit)
   - [pip-audit for Python](https://pypi.org/project/pip-audit/)
-  - [local-php-security-checker for PHP](https://github.com/fabpot/local-php-security-checker) или команда `symfony check:security`, если используется фреймворк [Symfony](https://symfony.com/)
-- Настрой dependabot, который будет автоматически обновлять версии библиотек
-- Убедись, что приложение достаточно защищено от актуальных уязвимостей - [OWASP TOP 10](https://owasp.org/www-project-top-ten/). Помочь в этом нелегком деле может [чеклист №1](https://github.com/shieldfy/API-Security-Checklist) и  [№2 (с примерами на Ruby on Rails)](https://github.com/brunofacca/zen-rails-security-checklist)
+  - [local-php-security-checker for PHP](https://github.com/fabpot/local-php-security-checker) or the  `symfony check:security` command, if you are using [Symfony](https://symfony.com/) framework
+- Set up dependabot to check and update library versions
+- Ensure that the app is protected against common vulnerabilities - [OWASP TOP 10](https://owasp.org/www-project-top-ten/). Here is a tool that can help with this difficult task [checklist №1](https://github.com/shieldfy/API-Security-Checklist) and [№2 (with examples for Ruby on Rails)](https://github.com/brunofacca/zen-rails-security-checklist)
 # CORS Headers (Cross-Origin Resource Sharing)
-Если запросы к твоему API будут делать из браузерных скриптов, например Single Page Aplication, построенных на современных Javascript фреймворках (React, Angular, Vue.js) и домен API будет отличаться от домена клиентского приложения, то нужно в API добавить CORS заголовки, чтобы браузер не блокировал ответы от API.
 
-Обычно, модуль для настройки CORS заголовков есть в http фреймворке и можно использовать его как по дефолту, так и с более тонкими настройками по необходимости. Например:
+When dealing with modern single page applications written in popular frameworks like React, Vue.js or Angular, you are likely to encounter a scenario where a client domain will be different from your API domain. In this case, your API will have to include CORS headers to let the browser know that responses coming from the API are permitted.
+
+Typically, a CORS module is already available in your framework of choice and you can use its defaults. If you need more a more granular configuration, here is a few libraries that can help: 
 - [Go Echo](https://echo.labstack.com/middleware/cors/)
 - [Javascript ExpressJS](https://expressjs.com/en/resources/middleware/cors.html)
 
-Подробнее про CORS заголовки можно прочитать [здесь](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
+You can learn more about CORS headers here [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
 
 # WIP: Transactions, Locks, Isolation Levels, ACID
 # WIP: Cache

--- a/EN.md
+++ b/EN.md
@@ -55,16 +55,16 @@ If you have a proposal about covering a specific technology here, don't be shy:
 * Repository settings must disable force pushing into (`push --force`) into main branches (`master`, `main`, release branches)
 * 'README' should contain:
   - info about the project
-  - short summary of tooling and technologies
+  - short summary of tooling and the tech stack
   - instructions for setting up and launching the application
 * Use feature branches, pull requests. Refer to this great [article](https://www.flagship.io/git-branching-strategies/) with comparison of different Git Branching Strategies. 
-* Readable commit history. Here is a good set of rules [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+* Use readable commit history. Here is a good set of rules [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
 * Set up Continuous Integration (Gitlab CI / Github Actions)
 * `feature/` and master branches should be set up with:
   * test runners and [coverage](https://www.guru99.com/test-coverage-in-software-testing.html) stats
   * linting  
 * Setting up Continuous Delivery - app delpoyment into differnet environmetns (e.g. test/staging/prod) would be a huge plus!
-* Setting up and launching [dependabot](https://docs.github.com/ru/code-security/dependabot/working-with-dependabot)
+* Optional: Set up [dependabot](https://docs.github.com/ru/code-security/dependabot/working-with-dependabot)
 
 # Code Style
 Before development:
@@ -75,27 +75,27 @@ Before development:
   * IDEA
   * Vim, emacs
 * [EditorConfig](https://editorconfig.org/) plugin / add-on is up and running for your editor
-* Code formatters are up and running: 
+* Set up Code formatters: 
   * Rubocop for Ruby
   * Pylint/Black/PEP8 for Python
 # ✔️Tests
-* Установлены библиотеки для написания тестов различных видов (unit, integration). Например:
+* Install libraries for writing various test types (unit, integration). For instance: 
    * Pytest for Python
    * RSpec for Ruby
    * Testify, testcontainers for Golang
-* После прогона тестов автоматически считается test coverage
-* Пишите unit-тесты по паттерну [AAA (Arange Act Assert)](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80)
+* Test coverage is calculated automatically after each test run
+* Apply [AAA (Arrange Act Assert)](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern when writing unit tests
 
-Старайтесь покрывать ваш код по [пирамиде тестирования](https://martinfowler.com/articles/practical-test-pyramid.html). Обратите внимание, что для тестов разного уровня могут использоваться разные инструменты. Для end to end тестирования можно использовать [Selenium](https://www.selenium.dev/) или [Cypress](https://www.cypress.io/how-it-works/). Для интеграционных удобно использовать `testcontainers`
+Try to adhere to the [testing pyramid] (https://martinfowler.com/articles/practical-test-pyramid.html) principle. Note that different test types require different tools. For end-to-end (e2e) testing you can try using [Selenium](https://www.selenium.dev/) or [Cypress](https://www.cypress.io/how-it-works/). Integration tests can be added via `testcontainers`.
 
 # ⚙️Configuration & Infrastructure around Code
-* На локальной машине разработчика установлены `Docker` и `docker-compose`
-* В репозитории есть Dockefile с помощью которого можно собрать приложение в `Docker container`
-  * [Best practices when writing a Dockerfile for a Ruby application](https://lipanski.com/posts/dockerfile-ruby-best-practices) (хотя советы применимы и к другим языкам)
+* Have `docker` and `docker-compose` installed on your local machine
+* There is a Dockerfile in your repository which can be used to build your app into a `Docker container`
+  * [Best practices when writing a Dockerfile for a Ruby application](https://lipanski.com/posts/dockerfile-ruby-best-practices) (although, these tips can be useful for other languages)
   * [Google Cloud: Best practices for building containers](https://cloud.google.com/architecture/best-practices-for-building-containers)
-* Все зависимости приложения (`PostgreSQL`, `S3`, `Redis`, `Kafka`, `RabbitMQ`) описаны в `docker-compose.yml`
-* Настройка приложения и запуск должны делаться максимально просто и прозрачно (для этого может понадобиться написать вспомогательные скрипты на `bash/zsh/powershell`)
-* [Приложение должно иметь несколько окружений (development, prod, test)](https://12factor.net/dev-prod-parity)
+* All app dependencies are listed in a `docker-compose.yml` file
+* Set up and launch ofr your application should be as easy nad straightforward. It is possible that you may need to write some additional `base/zsh/powershell` scripts
+* [Your application should have multiple environments (development, prod, test)](https://12factor.net/dev-prod-parity)
 * Для `production` сборки приложения используется рекомендуемый application сервер, например:
    * Puma for Ruby
    * Gunicorn3 for Python

--- a/EN.md
+++ b/EN.md
@@ -1,0 +1,261 @@
+# How to develop perfect CRUD
+[<img src="https://img.shields.io/badge/channel-telegram-blue">](https://t.me/careerunderhood) [<img src="https://img.shields.io/badge/message-telegram-blue">](https://t.me/ea_kozlov)
+
+# 🤔 What is this?
+This article is an attempt to combine best practices that are helpful to keep in mind when developing backend applications.
+
+It can be used as a checklist if:
+- You are starting a greenfield project and want to ensure that best practices are used right from the start.
+- You received a test assignment and have decided to move forward with it.
+ 
+## 🤔 Does this article only cover backend apps? 
+Because the author's expertise lies mostly on the backend side, most suggestions will be useful for developing backend apps. However, a lot of the points covered in this article can also be handy for other types of development.
+
+## 🤔 There is a lot in here, do I really need all of this?
+
+The more features and practices you adopt in your project, the better. Applying all of them at once would be hard so consider your time 🕒 and effort 💪 to prioritize specific practices.
+## 🤔 "This article is missing information about technology X"
+
+If you have a proposal about covering a specific technology here, don't be shy: 
+- Open an issue ✅
+- Open a PR ✅
+
+# 📖 Table of Contents
+<!-- TOC start -->
+- [Repository](#repository)
+- [Code Style](#code-style)
+- [✔️Tests](#%EF%B8%8Ftests)
+- [⚙️Configuration & Infrastructure around Code](#%EF%B8%8Fconfiguration--infrastructure-around-code)
+- [API Design](#api-design)
+- [Authorization & Authentification](#authorization--authentification)
+- [MVC Explanation](#mvc-explanation)
+  - [Controller](#controller)
+  - [Model](#model)
+  - [Service](#service)
+  - [View](#view)
+- [📐✏️👷‍♀️Architecture, Design Patterns, Refactoring, etc](#%EF%B8%8F%EF%B8%8Farchitecture-design-patterns-refactoring-etc)
+- [🔒CRUD: Validations](#crud-validations)
+- [CRUD: Database](#crud-database)
+- [CRUD: Operations](#crud-operations)
+  - [LIST (HTTP GET)](#list-http-get)
+  - [READ (HTTP GET)](#read-http-get)
+  - [CREATE (HTTP POST)](#create-http-post)
+  - [UPDATE (HTTP PUT/PATCH)](#update-http-putpatch)
+  - [DESTROY (HTTP DELETE)](#destroy-http-delete)
+- [External API Calls, Long-running tasks (And why we need message queue)](#external-api-calls-long-running-tasks-and-why-we-need-message-queue)
+- [📈Logs and Metrics](#logs-and-metrics)
+- [🛡️Security](#%EF%B8%8Fsecurity)
+- [CORS Headers (Cross-Origin Resource Sharing)](#cors-headers-cross-origin-resource-sharing)
+- [WIP: Transactions, Locks, Isolation Levels, ACID](#wip-transactions-locks-isolation-levels-acid)
+- [WIP: Cache](#wip-cache)
+- [WIP: Full Text Search](#wip-full-text-search)
+<!-- TOC end -->
+# Repository
+* Codebase has to live on a public or private Git repository (Github / Gitlab / Bitbucket)
+* Repository settings must disable force pushing into (`push --force`) into main branches (`master`, `main`, release branches)
+* 'README' should contain:
+  - info about the project
+  - short summary of tooling and technologies
+  - instructions for setting up and launching the application
+* Use feature branches, pull requests. Refer to this great [article](https://www.flagship.io/git-branching-strategies/) with comparison of different Git Branching Strategies. 
+* Readable commit history. Here is a good set of rules [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+* Set up Continuous Integration (Gitlab CI / Github Actions)
+* `feature/` and master branches should be set up with:
+  * test runners and [coverage](https://www.guru99.com/test-coverage-in-software-testing.html) stats
+  * linting  
+* Setting up Continuous Delivery - app delpoyment into differnet environmetns (e.g. test/staging/prod) would be a huge plus!
+* Setting up and launching [dependabot](https://docs.github.com/ru/code-security/dependabot/working-with-dependabot)
+
+# Code Style
+Before development:
+* Have a working editor or an IDE:
+  * VS Code
+  * Visual Studio
+  * PyCharm
+  * IDEA
+  * Vim, emacs
+* [EditorConfig](https://editorconfig.org/) plugin / add-on is up and running for your editor
+* Code formatters are up and running: 
+  * Rubocop for Ruby
+  * Pylint/Black/PEP8 for Python
+# ✔️Tests
+* Установлены библиотеки для написания тестов различных видов (unit, integration). Например:
+   * Pytest for Python
+   * RSpec for Ruby
+   * Testify, testcontainers for Golang
+* После прогона тестов автоматически считается test coverage
+* Пишите unit-тесты по паттерну [AAA (Arange Act Assert)](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80)
+
+Старайтесь покрывать ваш код по [пирамиде тестирования](https://martinfowler.com/articles/practical-test-pyramid.html). Обратите внимание, что для тестов разного уровня могут использоваться разные инструменты. Для end to end тестирования можно использовать [Selenium](https://www.selenium.dev/) или [Cypress](https://www.cypress.io/how-it-works/). Для интеграционных удобно использовать `testcontainers`
+
+# ⚙️Configuration & Infrastructure around Code
+* На локальной машине разработчика установлены `Docker` и `docker-compose`
+* В репозитории есть Dockefile с помощью которого можно собрать приложение в `Docker container`
+  * [Best practices when writing a Dockerfile for a Ruby application](https://lipanski.com/posts/dockerfile-ruby-best-practices) (хотя советы применимы и к другим языкам)
+  * [Google Cloud: Best practices for building containers](https://cloud.google.com/architecture/best-practices-for-building-containers)
+* Все зависимости приложения (`PostgreSQL`, `S3`, `Redis`, `Kafka`, `RabbitMQ`) описаны в `docker-compose.yml`
+* Настройка приложения и запуск должны делаться максимально просто и прозрачно (для этого может понадобиться написать вспомогательные скрипты на `bash/zsh/powershell`)
+* [Приложение должно иметь несколько окружений (development, prod, test)](https://12factor.net/dev-prod-parity)
+* Для `production` сборки приложения используется рекомендуемый application сервер, например:
+   * Puma for Ruby
+   * Gunicorn3 for Python
+   * Undertow for Java
+
+При описании конфигурации приложения используйте принципы 12factor. Изображение взято из статьи: [12 Factor App Revisited](https://architecturenotes.co/12-factor-app-revisited/)
+<img src="https://raw.githubusercontent.com/abstractart/how-to-develop-perfect-crud/main/12-Factor-app-revised.jpg">
+
+
+# API Design
+* Используй конвенции [REST](https://www.freecodecamp.org/news/rest-api-best-practices-rest-endpoint-design-examples/) как фундамент при именовании путей, типов операций и выборе статусов ответов API  
+* Формат данных: JSON (если не требуется другого)
+* В репозитории есть возможность открыть [Swagger](https://swagger.io/) спецификацию для знакомства с API
+  * Её можно написать самостоятельно
+  * А можно генерировать c помощью утилит: [rswag (Rails)](https://github.com/rswag/rswag), [safrs (Flask)](https://github.com/thomaxxl/safrs), [echo-swagger (Echo/Golang)](https://github.com/swaggo/echo-swagger)
+
+Если считаешь что связка REST+JSON не подходит под задачу, или по заданию требуется другой формат, то стоит изучить альтернативы:
+- [SOAP](https://www.w3.org/TR/soap12-part1/)
+- [gRPC](https://grpc.io/)
+- [GraphQL](https://graphql.org/)
+
+# Authorization & Authentification
+**Аутентификация** – процедура проверки подлинности, например, проверка подлинности пользователя путем сравнения введенного им пароля с паролем, сохраненным в базе данных.
+
+В качестве аутентификации по API можно использовать:
+* HTTP Basic Auth (простой путь)
+* JSON Web Tokens (посложнее)
+
+**Авторизация** – предоставление определенному лицу прав на выполнение определенных действий.
+Например: пользователь которого забанил администратор не может публиковать комментарии к постам (хотя он прошел аутентификацию на сайте).
+
+Примеры библиотек:
+- [Pundit for Ruby](https://github.com/varvet/pundit)
+- [Casbin (Many languages supported)](https://github.com/casbin/casbin)
+
+# MVC Explanation
+Цель: разделить обязанности в коде между компонентами. MVC это один из вариантов достижения цели и не требует от разработчика сильной когнитивной нагрузки (по сравнению с другими подходами)
+<img src="https://github.com/abstractart/how-to-develop-perfect-crud/blob/main/mvc-with-service.png?raw=true">
+## Controller
+- Принимает тело запроса, валидирует его на соответствие API
+- Проверяет authorization + authentification 
+- Вызывает Service, передает ему данные
+- На основе возвращаемого значения от Service вызывает код формирующий нужный ответ API (через View)
+## Model
+* Хранит только описание схемы данных и связи с другими моделями
+* Бизнес логики хранит по минимуму а лучше не хранит вообще
+* Используется для того чтобы делать запросы к БД на чтение и запись
+## Service
+* Принимает данные от контроллера, валидирует тело
+* Использует Model для чтения или записи данных в БД.
+* Отвечает за бизнес-логику приложения
+## View
+* Отвечает за то чтобы на основе данных сформировать API ответ.
+
+# 📐✏️👷‍♀️Architecture, Design Patterns, Refactoring, etc
+После того как MVC стал открытой книгой стоит углубиться и изучить:
+- подходы к построению архитектуры приложения
+- принципы которые помогают писать код устойчивый к изменениям.
+
+Бесплатные ресурсы, которые рекомендую для старта:
+- [Categorized overview of programming principles & design patterns](https://github.com/webpro/programming-principles)
+- [Refactoring Patterns and Design Patters Reference](https://refactoring.guru)
+- [Summary of "Clean code" by Robert C. Martin](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
+- [Summary of "Clean Architecture" by Robert C. Martin](https://gist.github.com/ygrenzinger/14812a56b9221c9feca0b3621518635b)
+
+# 🔒CRUD: Validations
+Перед тем как сохранять данные в БД обязательно:
+- отвалидируйте данные на тип (там где ожидается строка пришла строка, где int там int итп)
+- и соответствие тела запроса API (если пользователь отправил поля которые не имеет права отпралять в БД мы должны их игнорировать)
+# CRUD: Database
+* Используйте ORM (или что-то подобное), если в задании не указано что нужно писать чистый SQL.
+  * Проще для старта
+  * Безопасно (Большинство ORM предоставлют защиту от SQL injections из коробки)
+* Используйте механизм миграций чтобы создавать таблицы и другие сущности в вашей БД (Rails Migrations, Flask-Migrate, etc)
+* При описании таблиц важно сразу указать всем столбцам необходимые constraints (NULLABLE, DEFAULT VALUE, UNIQUE, PRIMARY KEY)
+* При описании таблиц важно сразу указать индексы для столбцов по которым ожидается поиск.
+* Для защиты API от перебора можно использовать как PRIMARY KEY `uuid` вместо `serial`
+
+
+P.S. При описании миграций полезно подсматривать [сюда](https://github.com/ankane/strong_migrations), чтобы не написать миграцию которая может заблокировать БД.
+# CRUD: Operations
+## LIST (HTTP GET)
+* Для каждого ресурса в ответе должно присутствовать ID.
+* Ресурсы должны быть отсортированными по какому либо признаку, например по времени создания.
+* API должен поддерживать пагинацию (чтобы не возвращать все сущности из БД за раз) [Разбор вариантов пагинации](https://dev.to/appwrite/this-is-why-you-should-use-cursor-pagination-4nh5)
+* Количество запросов к БД в рамках запроса должно быть фиксированным (Отсутствует [N+1 проблема](https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem-in-orm-object-relational-mapping))
+
+API не должно возвращать все поля модели.
+Пример: если наше API возвращает список постов то оно должно возвращать:
+  * ID
+  * Название поста
+  * Имя автора
+  * Первые несколько предложений статьи (превью)
+
+Полный текст поста для этого эндпоинта не нужен.
+
+## READ (HTTP GET)
+* Возвращаем полностью ресурс со всеми полями, ничего особенного
+## CREATE (HTTP POST)
+* Валидируем данные на предмет полей которые пользователь не имеет права изменять в БД а следовательно передавать.
+* Делаем в БД INSERT
+* Возвращаем в ответ ID и содержимое.
+
+Задачи со звездочкой:
+- Убедиться что реализованное API идемпотентно: [Подробнее](https://habr.com/ru/company/yandex/blog/442762/)
+- Настроить Rate Limiter чтобы защитить БД от спама и мусора
+## UPDATE (HTTP PUT/PATCH)
+* Разобраться в чем отличие между PUT и PATCH в HTTP
+* Валидировать тело запроса на предмет полей которые пользователь не имеет права изменять в БД а следовательно передавать.
+* Проверка права на редактирование у пользователя
+  * Например API не должно позволять пользователю редактировать чужие комментарии :)
+* Реализовать обновление согласно выбранному методу
+
+## DESTROY (HTTP DELETE)
+* Реализовать удаление предварительно проверив наличие сущности в БД и права на удаление у пользователя
+
+Дополнительно может быть полезно: реализовать soft удаление (скрываем от пользователя, оставляем в БД)
+# External API Calls, Long-running tasks (And why we need message queue)
+Если в рамках API требуется:
+- выполнять запросы к внешним системам
+- генерировать отчеты/выполнять долгие запросы к БД 
+то стоит подумать о том чтобы делать эти операции за пределами HTTP запроса. 
+
+Для этого может понадобиться очередь (Queue) в которую можно будет добавлять задачу (Task). 
+
+Примеры высокоуровневых библиотек которых решают задачу с постановкой, чтением и обработкой задач:
+* Celery for Python (Задачи хранятся в `Redis`)
+* Sidekiq for Ruby (Задачи хранятся в `Redis`)
+
+Стоит отметить, что `Redis` это не единственный вариант для хранения очереди + не для всех задач он подходит.
+Поэтому полезно изучить как минимум 2 более продвинутых варианта для хранения и обработки очередей: `RabbitMQ` и `Kafka`.
+
+Доп.ссылки:
+- [RabbitMQ и Apache Kafka: что выбрать](https://slurm.io/tpost/phdmogo9y1-rabbitmq-i-apache-kafka-chto-vibrat-i-mo)
+- [Latency, throughput, and availability: system design interview concepts](https://igotanoffer.com/blogs/tech/latency-throughput-availability-system-design-interview) - Подробнее о том, почему так важно чтобы HTTP запросы были быстрыми
+
+# 📈Logs and Metrics
+- Настроить Prometheus метрики с информацией о состоянии HTTP API и райнтайме приложения. Рекомендуется использовать готовые пакеты, которые собирают метрики о работе приложения по методикам [RED (Rate Error Duration)](https://www.infoworld.com/article/3638693/the-red-method-a-new-strategy-for-monitoring-microservices.html) и [USE (Utilization Saturation Errors)](https://www.brendangregg.com/usemethod.html):
+  - [prometheus, promauto, promhttp для Go](https://prometheus.io/docs/guides/go-application/)
+  - [starlette-prometheus для Python](https://github.com/perdy/starlette-prometheus)
+- [Логи должны писаться только в stdout](https://12factor.net/logs)
+- [Логи должны иметь строгий формат, например это может быть JSON](https://coralogix.com/blog/json-logging-why-how-what-tips/)
+
+
+# 🛡️Security
+- Убедись, что не используешь версии библиотек в которых есть уязвимости, проверять это можно автоматически с помощью утилит, например:
+  - [bundler-audit for Ruby](https://github.com/rubysec/bundler-audit)
+  - [pip-audit for Python](https://pypi.org/project/pip-audit/)
+  - [local-php-security-checker for PHP](https://github.com/fabpot/local-php-security-checker) или команда `symfony check:security`, если используется фреймворк [Symfony](https://symfony.com/)
+- Настрой dependabot, который будет автоматически обновлять версии библиотек
+- Убедись, что приложение достаточно защищено от актуальных уязвимостей - [OWASP TOP 10](https://owasp.org/www-project-top-ten/). Помочь в этом нелегком деле может [чеклист №1](https://github.com/shieldfy/API-Security-Checklist) и  [№2 (с примерами на Ruby on Rails)](https://github.com/brunofacca/zen-rails-security-checklist)
+# CORS Headers (Cross-Origin Resource Sharing)
+Если запросы к твоему API будут делать из браузерных скриптов, например Single Page Aplication, построенных на современных Javascript фреймворках (React, Angular, Vue.js) и домен API будет отличаться от домена клиентского приложения, то нужно в API добавить CORS заголовки, чтобы браузер не блокировал ответы от API.
+
+Обычно, модуль для настройки CORS заголовков есть в http фреймворке и можно использовать его как по дефолту, так и с более тонкими настройками по необходимости. Например:
+- [Go Echo](https://echo.labstack.com/middleware/cors/)
+- [Javascript ExpressJS](https://expressjs.com/en/resources/middleware/cors.html)
+
+Подробнее про CORS заголовки можно прочитать [здесь](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
+
+# WIP: Transactions, Locks, Isolation Levels, ACID
+# WIP: Cache
+# WIP: Full Text Search


### PR DESCRIPTION
- translated the text to English
- replaced links Russian links with english versions where possible:
  - REST API Idempotency: 
    - RU: https://habr.com/ru/companies/yandex/articles/442762/
    - EN: https://restfulapi.net/idempotent-rest-apis/
  -  Rabbit vs Apache Kafka:
  - RU: [RabbitMQ и Apache Kafka: что выбрать](https://slurm.io/tpost/phdmogo9y1-rabbitmq-i-apache-kafka-chto-vibrat-i-mo)
  - EN: N/A. There is no EN version of this article. How do we feel about using [this](https://www.interviewbit.com/blog/rabbitmq-vs-kafka/) article instead? 

I tried translating everything word-for-word, but I think the current draft turned out to be a bit cluttered. Here is an example:

> Убедиться что реализованное API идемпотентно: [Подробнее](https://habr.com/ru/company/yandex/blog/442762/) 

vs 

> Валидируем данные на предмет полей которые пользователь не имеет права изменять в БД а следовательно передавать.

I the former, we're saying "Ensure API idempotency across implemented endpoints ... etc", whereas the latter sounds like we're referring to a group of users. I can re-word the entire article as one or the other, but using both in the same article looks a bit odd.  